### PR TITLE
Allow the application id to be configured.  Default 'Marked 2.app'

### DIFF
--- a/lib/marked.coffee
+++ b/lib/marked.coffee
@@ -1,9 +1,14 @@
 exec = require("child_process").exec
 
 module.exports =
+  config:
+    application:
+      type: 'string'
+      default: 'Marked 2.app'
   activate: (state) ->
     atom.workspaceView.command "marked:open", => @openMarked()
 
   openMarked: ->
     path = atom.workspace.getActiveEditor().buffer?.file?.path
-    exec "open -a Marked.app \"#{path}\"" if path?
+    app = atom.config.get('marked.application')
+    exec "open -a \"#{app}\" \"#{path}\"" if path?


### PR DESCRIPTION
Recent versions of marked have switched 'Marked 2.app' for the application id so this package won't work with recent versions of marked 2.  I've made this a config setting now with the default being 'Marked 2.app'
